### PR TITLE
Add Venturalitica SDK to Open Source Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,7 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 - [GGRC Core](https://github.com/google/ggrc-core) - Google's governance, risk, and compliance platform (archived but historically significant).
 - [Govready](https://github.com/GovReady/govready-q) - Open-source GRC platform for automated compliance assessments.
 - [Probo](https://github.com/ProboCI/probo) - Open source compliance automation focused on continuous integration workflows.
+- [Venturalitica SDK](https://github.com/Venturalitica/venturalitica-sdk) - Open-source Python SDK (Apache-2.0) for EU AI Act and ISO 42001 compliance evidence generation from ML training pipelines. Produces OSCAL Assessment Results, CycloneDX ML BOM, bias audits, and Annex IV technical documentation as a byproduct of model training.
 
 ### Commercial Platforms
 


### PR DESCRIPTION
Adds [Venturalitica SDK](https://github.com/Venturalitica/venturalitica-sdk) to **Tools & Platforms → Open Source Platforms**.

Open-source Python SDK (Apache-2.0) for EU AI Act and ISO 42001 compliance evidence generation from ML training pipelines. Produces:

- Native NIST **OSCAL Assessment Results** (validated against NIST JSON schema)
- **CycloneDX ML BOM** (model and dataset provenance)
- Bias audits and Annex IV technical documentation

Fits alongside IBM's Trestle and Auditree in the OSCAL compliance-as-code tooling space, extending the pattern from traditional IT systems to AI/ML — directly relevant to the list's EU Cybersecurity & AI Regulations scope.