### PR TITLE
Add CISA KEV Deadline Planner

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,6 +161,7 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 ### Open Source Platforms
 
 - [Openlane](https://www.theopenlane.io/) - Comprehensive compliance automation platform for SOC 2, ISO 27001, and custom frameworks (Apache-2.0). Transforms compliance from static annual process to continuous collaborative workflow with risk register, policy management, evidence lifecycle, and control validation. ([GitHub](https://github.com/theopenlane) | [Docs](https://docs.theopenlane.io/))
+- [CISA KEV Deadline Planner](https://kev-deadline-planner.vercel.app/) - Turner Levey. Open-source browser tool for checking CISA Known Exploited Vulnerabilities and BOD 22-01 remediation due dates without login or tracking. ([GitHub](https://github.com/Turner-Levey/kev-deadline-planner))
 - [SOC 2 Reliability Guild](https://s2guild.org/) - A community creating standardized evaluation criteria to help GRC and TPRM practitioners assess how much weight to give a SOC 2 report when making vendor trust decisions. ([GitHub](https://github.com/SOC-2-Quality-Guild/s2guild.org))
 - [Comply](https://github.com/strongdm/comply) - SOC 2 compliance automation framework by StrongDM (Apache-2.0). Provides markdown-based policy templates and document pipeline for auditor-ready policies.
 - [Compliance Masonry](https://github.com/opencontrol/compliance-masonry) - CLI tool to build compliance documentation using OpenControl YAML schema. Supports FedRAMP, NIST, and other frameworks.


### PR DESCRIPTION
Adds one open-source compliance tool entry for the CISA KEV Deadline Planner.

Why it fits:
- Browser tool for CISA Known Exploited Vulnerabilities and BOD 22-01 remediation due-date planning.
- Public source, free to use, no login, and no tracking.
- Relevant to compliance, risk, audit, and cybersecurity teams tracking required remediation windows.

Duplicate checks:
- Searched README, issues, and PRs for `kev-deadline-planner`, `CISA KEV`, `BOD 22-01`, and `Known Exploited Vulnerabilities`; no existing suggestion found.

Disclosure: I built and maintain this tool. It is not affiliated with CISA.