### PR TITLE
Add The Integrity Framework to Security & Privacy

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 ### Security & Privacy
 
 - [SOC Reports (SOC 1/2/3)](https://www.aicpa.org/soc) - AICPA Service Organization Control reports. SOC 1 for financial reporting controls, SOC 2 for security/availability/confidentiality/processing integrity/privacy controls, SOC 3 for public distribution.
+- [The Integrity Framework](https://theintegrityframework.org/framework/v1) - Product trustworthiness standard for sub-enterprise AI tools where SOC 2 does not apply. Self-mapped against six pre-build vetoes via a public INTEGRITY.md, listed in a tier-badged directory. CC BY 4.0, forkable.
 - [ISO/IEC 27001](https://www.iso.org/isoiec-27001-information-security.html) - International standard for establishing an Information Security Management System (ISMS). Requires annual certification audits.
 - [ISO/IEC 27002](https://www.iso.org/standard/75652.html) - Implementation guidance for ISO 27001 controls.
 - [ISO/IEC 27017](https://www.iso.org/standard/43757.html) - Cloud security controls based on ISO 27002.


### PR DESCRIPTION
Adds **The Integrity Framework** to *Security & Privacy*.

A published standard for product trustworthiness aimed at sub-enterprise AI tools — the segment where SOC 2 doesn't apply (small products, single-team purchases, sub-$5K ARR contracts). Founders self-map against six pre-build vetoes via a public INTEGRITY.md and the directory at theintegrityframework.org publishes them with a Bronze or Silver tier badge.

- v1.0 spec: https://theintegrityframework.org/framework/v1
- JSON-LD: https://theintegrityframework.org/framework/v1.json
- INTEGRITY.md template: https://theintegrityframework.org/integrity-md
- License: CC BY 4.0, forkable