### PR TITLE
Add Tuning Engines AI compliance evidence entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,7 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 - [Hyperproof](https://hyperproof.io/) - Compliance operations platform for ongoing risk and compliance management. Workflow automation and continuous control monitoring.
 - [Komos](https://www.komos.ai/solutions/background-screening) - AI automation platform for regulated operations teams that need repeatable browser portal, document, and review queue workflows. Supports CRA operations, FCRA adverse action, insurance eligibility, and banking operations with run logs, screenshots, and audit trails.
 - [Sprinto](https://sprinto.com/) - Automated compliance platform for SOC 2, ISO 27001, GDPR, HIPAA.
+- [Tuning Engines](https://www.tuningengines.com/) - AI control and evidence plane for governed model, MCP, skill, and agent traffic. Captures policy decisions, approvals, cost analytics, traces, runtime state references, and outcomes for audit-ready AI operations.
 - [Oneleet](https://oneleet.com/) - Continuous compliance monitoring and automation platform.
 - [Scrut](https://scrut.io/) - Automated compliance platform with integrations for real-time monitoring.
 - [Thoropass](https://thoropass.com/) - Information security and compliance software.


### PR DESCRIPTION
Adds Tuning Engines to the commercial compliance platforms section.\n\nWhy this fits:\n- it captures audit-ready evidence for governed AI systems\n- it records policy decisions, approvals, cost analytics, traces, runtime state references, and outcomes\n- the change is one scoped entry in an existing section