### PR TITLE
Add Superhighway - regulatory research agent guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,7 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 - [OpenControl](http://open-control.org/) - YAML-based compliance documentation framework.
 - [ComplianceForge](https://www.complianceforge.com/) - Commercial policy libraries and toolkits for multiple frameworks.
 - [Regulations.gov](https://www.regulations.gov/) - US federal regulations repository.
+- [Superhighway](https://superhighway.walls.sh/guides/regulatory-research-agent) - Pay-per-call web search API for building regulatory research agents. Researches regulations, compliance requirements, and recent enforcement actions across live web sources, generating structured briefs with compliance checklists and penalty-exposure summaries. Structured JSON output, no signup or subscription.
 
 ### Regulatory Data Sources
 


### PR DESCRIPTION
Adds Superhighway to the **Compliance Specifications & Resources** section. Superhighway is a pay-per-call web search API for building regulatory research agents: its /search, /scrape, /research, and /news endpoints pull live web sources to generate structured compliance briefs covering scope, key regulatory bodies, core requirements, a compliance checklist, penalty exposure, and recent enforcement actions. Structured JSON output, no signup or monthly subscription — fits alongside the other live regulatory/registry data sources and pay-per-use compliance tools already listed. Linked guide shows the full Python build. https://superhighway.walls.sh/guides/regulatory-research-agent