### PR TITLE
Add FilingFirehose to Regulatory Data Sources (US SEC EDGAR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,14 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 
 ### Regulatory Data Sources
 
+Programmatic access to regulatory filings, corporate disclosures, and government registries for KYC/AML due diligence, ESG compliance, disclosure monitoring, and beneficial-owner verification.
+
+#### United States
+
+- [FilingFirehose](https://filingfirehose.com) - Risk-scored REST API over SEC EDGAR filings (8-K, 10-K, 10-Q, S-3). Free tier with red-flag classification (going-concern, restatement, cyber, officer departure, dilution) and per-ticker AI analysis reports. Companion open-source classifier at [buried-events-parser](https://github.com/jaablon/buried-events-parser) (MIT). Useful for continuous monitoring of vendor / portfolio-company disclosures and SOX/audit workflow triggers.
+
+#### Europe
+
 European government registries that lack public APIs - pay-per-use scrapers for KYC/AML due diligence, beneficial-owner verification, debtor and insolvency screening, and ESG compliance. Structured JSON output, no monthly subscription. All published on Apify Store under [@minute_contest](https://apify.com/minute_contest).
 
 - [Poland KRS Financial Statements Scraper](https://apify.com/minute_contest/poland-krs-financial-scraper) - Structured balance sheets and income statements parsed from the Polish National Court Register (KRS). Pay-per-use programmatic alternative to manual eKRS PDF lookups.


### PR DESCRIPTION
Adding FilingFirehose under Regulatory Data Sources with a US subsection alongside the existing European scrapers.

**What it is:** Programmatic access to SEC EDGAR filings (8-K, 10-K, 10-Q, S-3) with red-flag risk scoring built for continuous monitoring — going-concern language, restatements, cyber disclosures (Item 1.05), officer departures, and dilution risk (S-3/424B5). Useful for vendor / portfolio-company disclosure monitoring, SOX/audit workflow triggers, and beneficial-owner change detection.

**Fit with the list:** SEC EDGAR filings are the US analog of the European KRS/BORME/Handelsregister data covered by the existing @minute_contest scrapers. Structured JSON output, free tier, and pay-per-report tier.

**Open-source component:** The body-text classifier that powers the risk scores is MIT-licensed at [buried-events-parser](https://github.com/jaablon/buried-events-parser).

Disclosure: I maintain FilingFirehose.