### PR TITLE
Add FacturaDesk to Commercial Platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -240,6 +240,7 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 - [Workiva](https://www.workiva.com/) - Cloud platform for ESG, financial, and compliance reporting.
 - [TrustYourWebsite](https://trustyourwebsite.com) - Deterministic GDPR/cookie scanner for EU and UK SMBs. DOM queries, regex, axe-core, HTTP checks. LLM use restricted to report copy, not the compliance checks themselves.
 - [heygrc](https://heygrc.com/) - GitHub App that reviews pull requests against the compliance frameworks an organization must meet (ISO 27001, SOC 2, GDPR, EU AI Act, and more) and flags control-relevant changes inline, citing the specific control clause. By ISMS Copilot.
+- [FacturaDesk](https://facturadesk.eu/) - Done-for-you Peppol e-invoicing registration for Belgian businesses, ahead of Belgium's mandatory B2B e-invoicing rules. Includes a free public Peppol registration checker.
 
 ### Compliance Specifications & Resources
 


### PR DESCRIPTION
Adds FacturaDesk (https://facturadesk.eu/) to Commercial Platforms — a done-for-you Peppol e-invoicing registration service for Belgian businesses, ahead of Belgium's mandatory B2B e-invoicing rules. Includes a free public Peppol registration checker.