### PR TITLE
Add SSKG Hub (auditable KGs of sustainability standards) to Compliance Specifications & Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 - [Regulations.gov](https://www.regulations.gov/) - US federal regulations repository.
 - [Superhighway](https://superhighway.walls.sh/guides/regulatory-research-agent) - Pay-per-call web search API for building regulatory research agents. Researches regulations, compliance requirements, and recent enforcement actions across live web sources, generating structured briefs with compliance checklists and penalty-exposure summaries. Structured JSON output, no signup or subscription.
 - [Awesome Corporate Standards](https://github.com/openapi/awesome-corporate-standards) - Curated reference list of international standards, frameworks, and certification bodies for organizations, spanning ISO 9001/27001/14001, GDPR, PCI DSS, SOX, AS9100, ISO 13485, and sector-specific compliance.
+- [SSKG Hub](https://www.sskg-hub.com/) - Expert-guided platform that turns sustainability disclosure standards (GRI, SASB, TCFD, IFRS S2) into auditable, provenance-linked knowledge graphs — LLM-extracted, expert-certified, machine-queryable representations of the standards themselves ([paper](https://arxiv.org/abs/2603.00669)).
 
 ### Regulatory Data Sources
 


### PR DESCRIPTION
Adds **SSKG Hub** to **Tools & Platforms → Compliance Specifications & Resources**, alongside the machine-readable-compliance resources (NIST OSCAL, OpenControl).

SSKG Hub turns sustainability disclosure standards (**GRI, SASB, TCFD, IFRS S2** — the standards this list's ESG & Sustainability section catalogs) into auditable, provenance-linked **knowledge graphs**: LLM extraction produces a Draft KG, domain experts review and promote it to a Certified KG under role-based governance — a machine-queryable representation of the standards themselves. Public web platform: https://www.sskg-hub.com/ · paper: https://arxiv.org/abs/2603.00669

Follows the `- [Name](url) - description.` format (appended, matching the section's style). Disclosure: I am an author of the platform/paper.