### PR TITLE
Add SOC 2 Readiness Checklist for Startup CTOs

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,7 @@ This list is intended for **compliance officers, risk managers, auditors, and cy
 - [Regulations.gov](https://www.regulations.gov/) - US federal regulations repository.
 - [Superhighway](https://superhighway.walls.sh/guides/regulatory-research-agent) - Pay-per-call web search API for building regulatory research agents. Researches regulations, compliance requirements, and recent enforcement actions across live web sources, generating structured briefs with compliance checklists and penalty-exposure summaries. Structured JSON output, no signup or subscription.
 - [Awesome Corporate Standards](https://github.com/openapi/awesome-corporate-standards) - Curated reference list of international standards, frameworks, and certification bodies for organizations, spanning ISO 9001/27001/14001, GDPR, PCI DSS, SOX, AS9100, ISO 13485, and sector-specific compliance.
+- [SOC 2 Readiness Checklist for Startup CTOs](https://wizbang.pro/blog/soc2-readiness-checklist-startup-cto) - Practical 8-week SOC 2 Type II playbook for startup engineering leaders, covering IAM, infrastructure security, policy writing, monitoring, and auditor selection.
 
 ### Regulatory Data Sources
 


### PR DESCRIPTION
Adds a practical SOC 2 readiness checklist to the **Compliance Specifications & Resources** section.

The guide covers an 8-week SOC 2 Type II playbook for startup engineering leaders — covering IAM, infrastructure security, policy writing, monitoring, and auditor selection. It complements the existing compliance automation platforms in the list by providing a practitioner-focused implementation guide.