### PR TITLE
Add EU Regulatory Enforcement Tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,5 +289,6 @@ European government registries that lack public APIs - pay-per-use scrapers for 
 - [Austria Ediktsdatei Insolvency Scraper](https://apify.com/minute_contest/austria-ediktsdatei-scraper) - Bankruptcies and reorganizations (the official API requires an IWG license).
 - [Austria WKO Business Directory Scraper](https://apify.com/minute_contest/wko-business-directory-scraper) - 620,000+ Austrian business contacts from the WKO Chamber of Commerce.
 - [France Societe.com Company Scraper](https://apify.com/minute_contest/societe-com-scraper) - Directors, financials, and shareholders for French entities in a single call.
+- [EU Regulatory Enforcement Tracker](https://regdossier.eu/eu-enforcement-tracker/) - Consolidated public enforcement record across GDPR, NIS2, DORA, AI Act, CSRD, CBAM, CRA and EUDR, with national penalty ceilings and supervisory order counts per authority. Every figure links to its primary source. Free, no sign-up.
 
 [![CC0](https://mirrors.creativecommons.org/presskit/buttons/88x31/svg/cc-zero.svg)](https://creativecommons.org/publicdomain/zero/1.0/)


### PR DESCRIPTION
Adds the EU Regulatory Enforcement Tracker to Regulatory Data Sources / Europe.

It consolidates published enforcement outcomes for the eight main EU frameworks on one page, including national penalty ceilings and the number of supervisory orders issued per authority, each with a link to the primary source. It is free and requires no sign-up.

Disclosure: I maintain RegDossier, the publication behind this page.